### PR TITLE
feat: add ticket pagination

### DIFF
--- a/src/pages/InboxDarkMode.tsx
+++ b/src/pages/InboxDarkMode.tsx
@@ -66,9 +66,12 @@ export default function Inbox() {
     loading,
     error,
     lastFetch,
-    fetchTickets: loadTickets,
     reloadTickets,
-    searchTickets
+    searchTickets,
+    loadMoreTickets,
+    currentPage,
+    totalCount,
+    hasMore
   } = useOptimizedTickets({
     enableRealtime: true,
     batchSize: 50
@@ -780,7 +783,7 @@ export default function Inbox() {
 
           <div className="flex items-center gap-4 text-sm text-muted-foreground dark:text-muted-foreground">
             <span className="mx-0 px-0 my-[5px] py-0 text-base text-center">
-              {filteredTicketsWithStatus.length} de {optimizedTickets.length} tickets
+              {filteredTicketsWithStatus.length} de {totalCount} tickets
             </span>
             {(searchTerm || activeFilter !== 'all' || setorFilter !== 'all' || tagFilter !== 'todas' || dateSort !== 'none' || criticalitySort !== 'none') && <Button variant="ghost" size="sm" onClick={() => {
             setSearchTerm('');
@@ -812,6 +815,17 @@ export default function Inbox() {
                 </p>
               </CardContent>
             </Card> : filteredTicketsWithStatus.map(ticket => <JiraTicketCard key={ticket.id} ticket={ticket} onOpenDetail={handleOpenTicketDetail} onUpdateStatus={handleUpdateStatus} onEditTicket={handleEditTicket} onDeleteTicket={handleDeleteTicket} userCanEdit={canEdit} userCanDelete={canDelete} />)}
+
+          {hasMore && !loading && (
+            <div className="flex flex-col items-center py-4">
+              <Button onClick={loadMoreTickets} disabled={loading} variant="outline" size="sm">
+                Carregar mais
+              </Button>
+              <span className="mt-2 text-xs text-muted-foreground">
+                {optimizedTickets.length} de {totalCount}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Modals */}

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -48,10 +48,13 @@ interface Setor {
 
 export default function KanbanPage() {
   // Usar hook otimizado para tickets
-  const { 
-    tickets, 
-    loading, 
-    reloadTickets 
+  const {
+    tickets,
+    loading,
+    reloadTickets,
+    loadMoreTickets,
+    hasMore,
+    totalCount
   } = useOptimizedTickets({
     enableRealtime: true,
     batchSize: 100
@@ -501,8 +504,8 @@ export default function KanbanPage() {
                 <RefreshCw className="h-8 w-8 animate-spin text-primary" />
               </div>
             ) : viewMode === 'status' ? (
-              <TicketKanban 
-                tickets={filteredTickets} 
+              <TicketKanban
+                tickets={filteredTickets}
                 onOpenDetail={handleOpenTicketDetail}
                 onEditTicket={handleEditTicket}
                 onTicketUpdate={handleTicketUpdate}
@@ -519,6 +522,17 @@ export default function KanbanPage() {
             )}
           </CardContent>
         </Card>
+
+        {hasMore && !loading && (
+          <div className="flex flex-col items-center mt-4">
+            <Button onClick={loadMoreTickets} variant="outline" size="sm">
+              Carregar mais
+            </Button>
+            <span className="mt-2 text-xs text-muted-foreground">
+              {tickets.length} de {totalCount}
+            </span>
+          </div>
+        )}
 
         {/* Ticket Detail Modal */}
         {selectedTicket && (


### PR DESCRIPTION
## Summary
- add pagination support to useOptimizedTickets hook
- fetch additional ticket pages on demand in Inbox and Kanban pages
- surface total ticket count for user feedback

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 203 errors)


------
https://chatgpt.com/codex/tasks/task_b_68bb0f9c65408332b3bdc64ef918a04d