### PR TITLE
feat: centralize realtime channel management

### DIFF
--- a/src/lib/realtimeManager.ts
+++ b/src/lib/realtimeManager.ts
@@ -1,0 +1,44 @@
+import type { RealtimeChannel } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase/client';
+
+interface ChannelEntry {
+  channel: RealtimeChannel;
+  subscribers: number;
+}
+
+const channels: Record<string, ChannelEntry> = {};
+
+/**
+ * Retrieve a shared realtime channel and subscribe to it.
+ * The setup callback can register any event handlers before the
+ * channel is subscribed. Returns a cleanup function that should be
+ * called when the subscriber unmounts.
+ */
+export function subscribeToChannel(
+  name: string,
+  setup: (channel: RealtimeChannel) => void,
+): () => void {
+  let entry = channels[name];
+  if (!entry) {
+    entry = {
+      channel: supabase.channel(name),
+      subscribers: 0,
+    };
+    channels[name] = entry;
+  }
+
+  setup(entry.channel);
+
+  if (entry.subscribers === 0) {
+    entry.channel.subscribe();
+  }
+  entry.subscribers += 1;
+
+  return () => {
+    entry.subscribers -= 1;
+    if (entry.subscribers <= 0) {
+      supabase.removeChannel(entry.channel);
+      delete channels[name];
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- centralize Supabase realtime channel creation with `realtimeManager`
- refactor hooks to share and clean up realtime channels

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm test` *(fails: Missing script: "test"*)


------
https://chatgpt.com/codex/tasks/task_b_68bb11a9e248833298602094f0784b34