### PR TITLE
feat: schedule cleanup of old records

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,10 @@ npm run typecheck
 - Ticket → Setor (muitos para um)
 - Ticket → Usuário (muitos para um - criador)
 
+## 🧹 Política de Retenção de Dados
+
+Registros de tickets, logs e notificações são mantidos por 30 dias. A função Edge `cleanup-old-records` remove automaticamente itens mais antigos diariamente através de um job `cron` no Supabase.
+
 ---
 
 ## 📞 Suporte

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -56,3 +56,6 @@ port = 54330
 
 [functions.generate-sla-tags]
 verify_jwt = false
+[functions.cleanup-old-records]
+verify_jwt = false
+

--- a/supabase/functions/cleanup-old-records/index.ts
+++ b/supabase/functions/cleanup-old-records/index.ts
@@ -1,0 +1,45 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? ''
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    const retentionDays = parseInt(Deno.env.get('RETENTION_DAYS') ?? '30')
+
+    const supabase = createClient(supabaseUrl, supabaseKey)
+
+    const cutoffDate = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString()
+    const tables = ['tickets', 'logs', 'notifications']
+    const results: Record<string, string> = {}
+
+    for (const table of tables) {
+      const { error } = await supabase
+        .from(table)
+        .delete()
+        .lt('created_at', cutoffDate)
+
+      results[table] = error ? `error: ${error.message}` : 'ok'
+    }
+
+    return new Response(
+      JSON.stringify({ cutoff: cutoffDate, results }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  } catch (error) {
+    console.error('Cleanup error:', error)
+    return new Response(
+      JSON.stringify({ error: 'Cleanup failed', details: error.message }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 500 }
+    )
+  }
+})

--- a/supabase/migrations/20250815120000_schedule_cleanup_old_records.sql
+++ b/supabase/migrations/20250815120000_schedule_cleanup_old_records.sql
@@ -1,0 +1,10 @@
+-- Schedule daily cleanup of old records via edge function
+select cron.schedule(
+  'cleanup_old_records',
+  '0 3 * * *',
+  $$
+  select net.http_post(
+    url := 'http://localhost:54321/functions/v1/cleanup-old-records'
+  );
+  $$
+);


### PR DESCRIPTION
## Summary
- add edge function to purge outdated tickets, logs and notifications
- schedule daily cron job to invoke cleanup
- document data retention policy

## Testing
- `npm run lint` *(fails: Unexpected any, prefer-const, no-case-declarations, @typescript-eslint/no-require-imports)*
- `npx eslint supabase/functions/cleanup-old-records/index.ts`


------
https://chatgpt.com/codex/tasks/task_b_68bb131e7298833294090e6ee84f9e06